### PR TITLE
simplify dependencies and std/alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,12 @@ all-features = true
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
 alloc = []
 arrayvec = ["dep:arrayvec"]
 
 [dependencies]
 arrayvec = { version = "0.7.6", optional = true, default-features = false }
-cfg-if = "1"
 paste = "1"
 
 [[example]]
@@ -32,4 +31,4 @@ required-features = ["std"]
 
 [[example]]
 name = "bson"
-required-features = ["std"]
+required-features = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 [features]
 default = ["std"]
-std = ["thiserror/std"]
+std = ["thiserror?/std"]
 alloc = []
 arrayvec = ["dep:arrayvec"]
 
@@ -25,7 +25,7 @@ arrayvec = ["dep:arrayvec"]
 arrayvec = { version = "0.7.6", optional = true, default-features = false }
 cfg-if = "1"
 paste = "1"
-thiserror = { version = "2", default-features = false }
+thiserror = { version = "2", optional = true, default-features = false }
 
 [[example]]
 name = "json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 [features]
 default = ["std"]
-std = ["thiserror?/std"]
+std = []
 alloc = []
 arrayvec = ["dep:arrayvec"]
 
@@ -25,7 +25,6 @@ arrayvec = ["dep:arrayvec"]
 arrayvec = { version = "0.7.6", optional = true, default-features = false }
 cfg-if = "1"
 paste = "1"
-thiserror = { version = "2", optional = true, default-features = false }
 
 [[example]]
 name = "json"

--- a/src/combinators/be.rs
+++ b/src/combinators/be.rs
@@ -8,12 +8,14 @@ use crate::Encoder;
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::BE;
 ///
 /// let mut buf = Vec::new();
 /// BE::new(1u16).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, &[0, 1], "Encoding a u16 in big-endian order means the most significant byte comes first");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BE<E> {

--- a/src/combinators/cond.rs
+++ b/src/combinators/cond.rs
@@ -5,6 +5,7 @@ use core::ops::Deref;
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::Cond;
 /// use std::ffi::CStr;
@@ -19,6 +20,7 @@ use core::ops::Deref;
 ///
 /// Cond::new(c"", non_empty).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, b"", "An empty CStr does not produce any output");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Cond<E, F> {

--- a/src/combinators/flags.rs
+++ b/src/combinators/flags.rs
@@ -9,21 +9,25 @@ use crate::Encoder;
 /// # Examples
 ///
 /// ```
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::Flags;
 ///
 /// let mut buf = Vec::new();
 /// Flags::new([false,false,false,false,false,false,false, false]).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, &[0]);
+/// # }
 /// ```
 ///
 /// ```
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::Flags;
 ///
 /// let mut buf = Vec::new();
 /// Flags::new([true,false,false,true,false,false,false, false]).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, &[0b1001_0000]);
+/// # }
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]

--- a/src/combinators/from_error.rs
+++ b/src/combinators/from_error.rs
@@ -8,12 +8,14 @@ use core::ops::Deref;
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::FromError;
 ///
 /// let mut buf = Vec::new();
 /// FromError::<_, std::num::TryFromIntError>::new("hello").encode(&mut buf).unwrap();
 /// assert_eq!(&buf, b"hello");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]

--- a/src/combinators/iter.rs
+++ b/src/combinators/iter.rs
@@ -3,6 +3,7 @@
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::Iter;
 ///
@@ -13,6 +14,7 @@
 /// let mut buf = Vec::new();
 /// Iter::new(&compact_map).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, b"hello\0\x01world\0\x02");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]

--- a/src/combinators/le.rs
+++ b/src/combinators/le.rs
@@ -8,12 +8,14 @@ use crate::Encoder;
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::LE;
 ///
 /// let mut buf = Vec::new();
 /// LE::new(1u16).encode(&mut buf).unwrap();
 /// assert_eq!(&buf, &[1, 0], "Encoding a u16 in little-endian order means the least significant byte comes first");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LE<E> {

--- a/src/combinators/length_prefix.rs
+++ b/src/combinators/length_prefix.rs
@@ -3,6 +3,7 @@
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::LengthPrefix;
 /// use encode::combinators::FromError;
@@ -11,6 +12,7 @@
 /// let mut buf = Vec::new();
 /// LengthPrefix::<_, u8, TryFromIntError>::new("hello").encode(&mut buf).unwrap();
 /// assert_eq!(&buf, b"\x05hello", "Using a single byte to indicate the length of the string");
+/// # }
 /// ```
 #[doc(alias("length", "prefix", "TLV"))]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -33,8 +33,8 @@
 //! | [`LengthPrefix`] | Encodes a value after its size. |
 //! | [`Iter`] | Encodes an iterator of encodables as a sequence. |
 #![cfg_attr(
-    any(feature = "std", feature = "alloc"),
-    doc = r#"## std/alloc encodables (requires `std` or `alloc` feature)
+    feature = "alloc",
+    doc = r#"## alloc encodables (requires `alloc` feature)
 
 |         Type|                                                       Description |
 |-------------|-------------------------------------------------------------------|

--- a/src/combinators/separated.rs
+++ b/src/combinators/separated.rs
@@ -3,6 +3,7 @@
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "alloc")] {
 /// use encode::Encodable;
 /// use encode::combinators::Separated;
 ///
@@ -10,6 +11,7 @@
 /// let array = ["hello", "world", "another"];
 /// Separated::new(&array, ", ").encode(&mut buf).unwrap();
 /// assert_eq!(&buf, b"hello, world, another");
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Separated<I, S> {

--- a/src/encoders/alloc.rs
+++ b/src/encoders/alloc.rs
@@ -1,16 +1,6 @@
-cfg_if::cfg_if!(
-    if #[cfg(feature = "std")] {
-        use std as reexport;
-    } else if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-
-        use alloc as reexport;
-    }
-);
-
-use reexport::vec::Vec;
-
 use crate::Encoder;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 impl Encoder for Vec<u8> {
     type Error = core::convert::Infallible;
@@ -28,7 +18,7 @@ impl Encoder for Vec<u8> {
 
 #[cfg(test)]
 mod test {
-    use crate::Encoder;
+    use super::*;
 
     #[test]
     fn assert_that_vec_grows() {

--- a/src/encoders/errors.rs
+++ b/src/encoders/errors.rs
@@ -4,6 +4,12 @@
 /// ([`&mut [u8]`](slice)) when there is no space left in the buffer.
 ///
 /// [`Encoder`]: crate::Encoder
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, thiserror::Error)]
-#[error("The provided buffer has no space left for encoding")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InsufficientSpace;
+
+impl core::error::Error for InsufficientSpace {}
+impl core::fmt::Display for InsufficientSpace {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "The provided buffer has no space left for encoding")
+    }
+}

--- a/src/encoders/mod.rs
+++ b/src/encoders/mod.rs
@@ -10,20 +10,20 @@
 //! - [`SizeEncoder`]: counts the number of bytes written.
 //! - [`&mut [u8]`](slice): writes bytes into a slice, if there is enough space.
 #![cfg_attr(
-    any(feature = "std", feature = "alloc"),
+    feature = "alloc",
     doc = "- [`Vec<u8>`] (`std` or `alloc` feature): writes bytes into a vector that grows if necessary."
 )]
 #![cfg_attr(
     feature = "arrayvec",
     doc = "- [`ArrayVec`](::arrayvec::ArrayVec) (`arrayvec` feature): writes bytes into an ArrayVec, if there is enough space."
 )]
+#[cfg(feature = "alloc")]
+mod alloc;
 #[cfg(feature = "arrayvec")]
 mod arrayvec;
 mod errors;
 mod size;
 mod slices;
-#[cfg(any(feature = "std", feature = "alloc"))]
-mod std_alloc;
 
 pub use errors::InsufficientSpace;
 pub use size::SizeEncoder;

--- a/src/impls/alloc.rs
+++ b/src/impls/alloc.rs
@@ -1,20 +1,7 @@
-cfg_if::cfg_if!(
-    if #[cfg(feature = "std")] {
-        use std as reexport;
-    } else if #[cfg(feature = "alloc")] {
-        extern crate alloc;
-
-        use alloc as reexport;
-    }
-);
-
-use reexport::borrow::Cow;
-use reexport::boxed::Box;
-use reexport::string::String;
-use reexport::vec::Vec;
-
 use crate::Encodable;
 use crate::Encoder;
+#[cfg(feature = "alloc")]
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 
 impl<E: Encoder> Encodable<E> for Vec<u8> {
     type Error = E::Error;

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -1,7 +1,7 @@
+#[cfg(feature = "alloc")]
+mod alloc;
 mod fmt;
 mod option_result;
 mod primitives;
 mod slices;
-#[cfg(any(feature = "std", feature = "alloc"))]
-mod std_alloc;
 mod tuples;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 #![warn(clippy::pedantic)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod combinators;
 pub mod encoders;
 mod impls;


### PR DESCRIPTION
I've divided this PR in incremental commits for clarity.

Error is implemented manually in the bson example, to illustrate what the thiserror crate was doing. Feel free to remove it and replace it the with `Box<dyn Error>` if it's too much boilerplate.