### PR TITLE
feat: Add bytes support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ default = ["std"]
 std = ["alloc"]
 alloc = []
 arrayvec = ["dep:arrayvec"]
+bytes = ["dep:bytes"]
 
 [dependencies]
 arrayvec = { version = "0.7.6", optional = true, default-features = false }
+bytes = { version = "1.10.1", optional = true, default-features = false }
 paste = "1"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ crate.
 - `std`: Enables the use of the standard library.
 - `alloc`: Enables the use of the `alloc` crate.
 - `arrayvec`: Implements [`Encodable`] for [`arrayvec::ArrayVec`].
+- `bytes`: Implements [`Encodable`] for [`bytes::BytesMut`].
 
 ## FAQs
 

--- a/src/encoders/bytes.rs
+++ b/src/encoders/bytes.rs
@@ -1,0 +1,37 @@
+use bytes::BufMut;
+use bytes::BytesMut;
+
+use crate::Encoder;
+
+impl Encoder for BytesMut {
+    type Error = core::convert::Infallible;
+
+    fn put_slice(&mut self, slice: &[u8]) -> Result<(), Self::Error> {
+        BufMut::put_slice(self, slice);
+        Ok(())
+    }
+
+    fn put_byte(&mut self, byte: u8) -> Result<(), Self::Error> {
+        BufMut::put_u8(self, byte);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Encodable;
+
+    use super::*;
+
+    #[test]
+    fn assert_that_bytesmut_can_be_used_as_encoder() {
+        let mut buf = BytesMut::new();
+        let encodable = "hello";
+
+        encodable.encode(&mut buf).unwrap();
+        let bytes = buf.freeze();
+
+        assert_eq!(bytes.len(), 5, "The buffer should contain 5 bytes");
+        assert_eq!(bytes, b"hello"[..]);
+    }
+}

--- a/src/encoders/mod.rs
+++ b/src/encoders/mod.rs
@@ -17,10 +17,16 @@
     feature = "arrayvec",
     doc = "- [`ArrayVec`](::arrayvec::ArrayVec) (`arrayvec` feature): writes bytes into an ArrayVec, if there is enough space."
 )]
+#![cfg_attr(
+    feature = "bytes",
+    doc = "- [`BufMut`](::bytes::BufMut) (`bytes` feature): writes bytes into an BufMut. Note that encoding will be more efficient if the BufMut is already pre-allocated."
+)]
 #[cfg(feature = "alloc")]
 mod alloc;
 #[cfg(feature = "arrayvec")]
 mod arrayvec;
+#[cfg(feature = "bytes")]
+mod bytes;
 mod errors;
 mod size;
 mod slices;


### PR DESCRIPTION
Introduces support for the `bytes` crate, enabling the use of `BytesMut` as an encoder. The most important changes include updating dependencies, modifying documentation, and adding a new encoder implementation.