### PR TITLE
Implement `Encodable<E>` for more `Cow`s

### DIFF
--- a/src/encoders/alloc.rs
+++ b/src/encoders/alloc.rs
@@ -1,5 +1,4 @@
 use crate::Encoder;
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 impl Encoder for Vec<u8> {

--- a/src/impls/alloc.rs
+++ b/src/impls/alloc.rs
@@ -1,6 +1,5 @@
 use crate::Encodable;
 use crate::Encoder;
-#[cfg(feature = "alloc")]
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 
 impl<E: Encoder> Encodable<E> for Vec<u8> {

--- a/src/impls/alloc.rs
+++ b/src/impls/alloc.rs
@@ -1,6 +1,6 @@
 use crate::Encodable;
 use crate::Encoder;
-use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
+use alloc::{borrow::Cow, borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 
 impl<E: Encoder> Encodable<E> for Vec<u8> {
     type Error = E::Error;

--- a/src/impls/alloc.rs
+++ b/src/impls/alloc.rs
@@ -20,9 +20,10 @@ impl<E: Encoder, T: Encodable<E>> Encodable<E> for Box<T> {
     }
 }
 
-impl<E: Encoder, T: Encodable<E>> Encodable<E> for Cow<'_, T>
+impl<E, T> Encodable<E> for Cow<'_, T>
 where
     T: ToOwned + Encodable<E> + ?Sized,
+    E: Encoder,
 {
     type Error = T::Error;
 


### PR DESCRIPTION
This should not break anything.

There is an `impl ToOwned for T where T: Clone` so changing that bound should allow strictly more things.

Removing the implicit `Sized` bound should also just allow for strictly more things (although anything that is `Clone` is also `Sized` so this one wouldn't do anything on its own).

Both of these are needed for byte slices in `Cow`s to work.

I've added a test that failed before the changes and works now.

What might be confusing is that simply calling `Cow::Borrowed(&[][..]).encode(&mut ()).unwrap()` would have also worked even before the changes, but it would use the `[u8]` implementation instead of the `Cow<'_, [u8]>` one.