### PR TITLE
feat: bool arrays can now be used to encode bitflags

### DIFF
--- a/src/combinators/flags.rs
+++ b/src/combinators/flags.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use core::fmt::Debug;
 use core::ops::Deref;
 
@@ -31,6 +33,7 @@ use crate::Encodable;
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
+#[deprecated(since = "0.3.0", note = "Use `[bool; 8]` directly instead")]
 pub struct Flags([bool; 8]);
 
 impl Flags {

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -22,10 +22,12 @@
 //! | [`(...)`](tuple) | Encodes a tuple by encoding each element in order |
 //! | [`i8`] and [`u8`] | Encodes a single byte |
 //! | [`char`] | Encodes a character as its UTF-8 byte representation |
-//! | [`&str`](str) | Encodes a UTF-8 string |
-//! | [`&CStr`](core::ffi::CStr) | Encodes a C string, including the null terminator (`\0`) |
-//! | [`&[u8]`](slice) | Encodes a byte slice |
-//! | [`Arguments`](core::fmt::Arguments) | Encodes formatted data from [`format_args!]` with zero allocations |
+//! | [`str`] | Encodes a UTF-8 string slice |
+//! | [`CStr`](core::ffi::CStr) | Encodes a C string slice, including the null terminator (`\0`) |
+//! | [`[u8; N]`](array) | Encodes a byte array |
+//! | [`[u8]`](slice) | Encodes a byte slice |
+//! | [`[bool; 8]`](array) | Encodes a set of flags as a single byte |
+//! | [`Arguments`](core::fmt::Arguments) | Encodes formatted data from [`format_args]` with zero allocations |
 //!
 //! ## Composition and Flow Combinators
 //!
@@ -37,7 +39,6 @@
 //! | [`Option`] | Encodes the inner value if `Some`; does nothing if `None` |
 //! | [`Result`] | Encodes the value on [`Ok`]; returns the error on [`Err`] |
 //! | [`Cond`] | Encodes a value only if a condition is met |
-//! | [`Flags`] | Encodes a set of bit flags packed into a single byte |
 //! | [`LE`] | Encodes a number in little-endian order |
 //! | [`BE`] | Encodes a number in big-endian order |
 //! | [`LengthPrefix`] | Encodes a length prefixed value ([TLV](https://en.wikipedia.org/wiki/Type–length–value)) |
@@ -93,6 +94,7 @@ mod separated;
 
 pub use be::BE;
 pub use cond::Cond;
+#[allow(deprecated)]
 pub use flags::Flags;
 pub use from_error::FromError;
 pub use iter::Iter;

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -27,7 +27,7 @@
 //! | [`[u8; N]`](array) | Encodes a byte array |
 //! | [`[u8]`](slice) | Encodes a byte slice |
 //! | [`[bool; 8]`](array) | Encodes a set of flags as a single byte |
-//! | [`Arguments`](core::fmt::Arguments) | Encodes formatted data from [`format_args]` with zero allocations |
+//! | [`Arguments`](core::fmt::Arguments) | Encodes formatted data from [`format_args`] with zero allocations |
 //!
 //! ## Composition and Flow Combinators
 //!


### PR DESCRIPTION
It doesn't make much sense to have the `Flags` combinator when we can just run the encoder over the boll array.